### PR TITLE
Add a Cleaner for Tracker Needle Desktop Search

### DIFF
--- a/pending/tracker_needle.xml
+++ b/pending/tracker_needle.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2012 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="tracker-needle" os="linux">
+  <label>Tracker Needle</label>
+  <description>Search tool</description>
+  <option id="history">
+    <label>Search history</label>
+    <description>Delete the search history</description>
+    <action command="delete" search="file" path="~/.local/share/tracker/tracker-needle.txt"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Only one option, which will remove a file containing search history, saving around 4 KiB.

Tested on Fedora 19 with Tracker Needle 0.16.1 and BleachBit 0.9.5.

Tracker Needle is a part of Tracker semantic data storage. Project homepage: http://projects.gnome.org/tracker/
