### PR TITLE
PlayOnLinux

### DIFF
--- a/pending/playonlinux.xml
+++ b/pending/playonlinux.xml
@@ -29,6 +29,7 @@
 		<description>Delete common component installation files cached by PlayOnLinux</description>
 		
 		<action search="walk.all" command="delete" path="~/.PlayOnLinux/resources" />
+		<action search="walk.all" command="delete" path="~/.PlayOnLinux/ressources" /><!--WORKAROUND: Typo in PlayOnLinux-->
 	</option>
 	
 	<option id="playonlinux-tmp">


### PR DESCRIPTION
Adds three cleaner actions for PlayOnLinux.

Space freed for each of these actions on my system:
- Resource cache: 893MB !!!
- Temporary WINE files: 132MB
- Temporary files: 29kB

-> 1GB of space freeable!!!
