### PR TITLE
Add cleaner for gvfs metadata

### DIFF
--- a/pending/gvfs.xml
+++ b/pending/gvfs.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2013 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="gvfs" os="linux">
+  <label>GNOME</label>
+  <description>The GNOME desktop environment</description>
+  <option id="metadata">
+    <label>GVFS Metadata</label>
+    <description>Delete metadata about previously mounted filesystems</description>
+    <action command="delete" search="glob" path="~/.local/share/gvfs-metadata/*"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
deletes ~/.local/share/gvfs-metadata/*, please test
https://wiki.gnome.org/action/show/Projects/gvfs
