### PR TITLE
7-Zip History

### DIFF
--- a/pending/7-Zip
+++ b/pending/7-Zip
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2013 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+
+
+<!-- 7-Zip stores history in the windows Registry, so this cleaner is more aimed towards maintaining privacy rather then freeing up disk space -->
+-<!-- 2McCoy7 (10/01/2014): tested on Windows 7 and BleachBit 1.0 -->
+
+
+<cleaner id="7-Zip" os="windows">
+  <label>7-Zip</label>
+  <option id="history">
+    <label>History</label>
+    <description>Delete History</description>
+    <action command="winreg" path="HKCU\Software\7-Zip\Compression" name="ArcHistory"/>
+    <action command="winreg" path="HKCU\Software\7-Zip\Extraction" name="PathHistory"/>
+	<action command="winreg" path="HKCU\Software\7-Zip\FM" name="FolderHistory"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
As stated in the comments this cleaner is to wipe 7-Zip history clean which is stored in Windows Registry for some reason. Feel free to have a look at other versions of Windows to see if any lines need to be added. Thanks for your time.

2McCoy7
