### PR TITLE
Create minetest.xml

### DIFF
--- a/pending/minetest.xml
+++ b/pending/minetest.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2013 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="minetest">
+  <label>Minetest</label>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the cache</description>
+    <action command="delete" search="walk.all" path="~/.minetest/cache/"/>
+  </option>
+  <option id="debug_logs">
+    <label>Debug logs</label>
+    <description>Delete the debug logs</description>
+    <action command="delete" search="file" path="~/.minetest/debug.txt"/>
+  </option>
+  <option id="favorite_server_list">
+    <label>Favorite server list</label>
+    <description>Delete the list of favorite servers</description>
+    <action command="delete" search="file" path="~/.minetest/client/serverlist/favoriteservers.txt"/>
+  </option>
+  <option id="mod_settings">
+    <label>Mod settings</label>
+    <description>Delete each worlds enable/disable settings for mods</description>
+    <action command="delete" search="glob" path="~/.minetest/worlds/*/world.mt"/>
+  </option>
+  <option id="mods">
+    <label>Mods</label>
+    <description>Delete all mods</description>
+    <action command="delete" search="walk.all" path="~/.minetest/mods/"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Tested on Chakra 2014.02 "Curie", Minetest 0.4.9
After a few weeks of using minetest, this cleaner erased:
  Cache: 39.0 MiB
  Debug logs: 595.4 MiB
  Favorite server list: 828 B
  Total: 634.4 MiB
(Mod settings & Mods will vary greatly depending on the user, so they aren't included in above stats)
home page: http://www.minetest.net/
Popularity stats: Currently has roughly 30 public servers: http://servers.minetest.net/
