### PR TITLE
Remove mod settings option

### DIFF
--- a/pending/minetest.xml
+++ b/pending/minetest.xml
@@ -36,11 +36,6 @@
     <description>Delete the list of favorite servers</description>
     <action command="delete" search="file" path="~/.minetest/client/serverlist/favoriteservers.txt"/>
   </option>
-  <option id="mod_settings">
-    <label>Mod settings</label>
-    <description>Delete each worlds enable/disable settings for mods</description>
-    <action command="delete" search="glob" path="~/.minetest/worlds/*/world.mt"/>
-  </option>
   <option id="mods">
     <label>Mods</label>
     <description>Delete all mods</description>


### PR DESCRIPTION
Deleting ~/.minetest/worlds/*/world.mt will break a world if it uses a game other then minetest or a back end other then sqlight3 (the defaults). Currently you can somewhat safely (somewhat safely because you're removing a mod, no matter how you remove a mod, there can be leftover 'unknown nodes' in the world from the mod) clear each line except "gameid = <something>"and "backend = <something>"; More important lines like those two are planned in the future. But I don't know how this could be implemented in CleanerML 
