### PR TITLE
clarify what mods option does

### DIFF
--- a/pending/minetest.xml
+++ b/pending/minetest.xml
@@ -38,7 +38,7 @@
   </option>
   <option id="mods">
     <label>Mods</label>
-    <description>Delete all mods</description>
+    <description>Delete all mods. Any blocks or items from a mod in a world will still become 'unknown'</description>
     <action command="delete" search="walk.all" path="~/.minetest/mods/"/>
   </option>
 </cleaner>


### PR DESCRIPTION
Currently, no matter how you remove a mod, any blocks or items from the mod in a world will become 'unknown' after removing or disabling the mod; This cleaner does not remedy this issue.
