### PR TITLE
Create amarok.xml

### DIFF
--- a/pending/amarok.xml
+++ b/pending/amarok.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2014 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="amarok">
+  <label>Amarok</label>
+  <description>Media player</description>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the album cover cache</description>
+    <!-- Chakra 2014.02 has ~/.kde4/share/apps/amarok/ -->
+    <action command="delete" search="walk.files" path="~/.kde4/share/apps/amarok/albumcovers/cache/"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Tested on Chakra 2014.02 "Curie", Amarok 2.8.0
After a few months of using amarok, this cleaner erased 1.5 MiB from the album cover cache.
home page: http://amarok.kde.org/
Popularity stats: The English amarok irc channel (irc.freenode.net #amarok) typically has around 90 people.
