### PR TITLE
Add warning for minetest mod removal.

### DIFF
--- a/pending/minetest.xml
+++ b/pending/minetest.xml
@@ -38,7 +38,8 @@
   </option>
   <option id="mods">
     <label>Mods</label>
-    <description>Delete all mods. Any blocks or items from a mod in a world will still become 'unknown'</description>
+    <description>Delete all mods.</description>
+    <warning>Any blocks or items from a removed mod in a world will become 'unknown'</warning>
     <action command="delete" search="walk.all" path="~/.minetest/mods/"/>
   </option>
 </cleaner>


### PR DESCRIPTION
Fix for 9eafc6084c8ecd7ad302642cbbff287b75bd09c9, removing a mod will make the items/blocks from this mod still present in a world appear as 'unknown'.
