### PR TITLE
Create minetest_classic.xml

### DIFF
--- a/pending/minetest_classic.xml
+++ b/pending/minetest_classic.xml
@@ -19,7 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<cleaner id="minetest_classic">
+<cleaner id="minetest_classic" os="linux">
   <label>Minetest Classic</label>
   <description>3D voxel world game</description>
   <option id="debug_logs">


### PR DESCRIPTION
Tested on Chakra 2014.02 "Curie", Minetest Classic 1404.00
After some time of using minetest classic, this cleaner erased 23.3 MiB of debug logs
home page: http://minetest-classic.com/
