### PR TITLE
add and release cleaner for gthumb (https://wiki.gnome.org/Apps/gthumb)

### DIFF
--- a/release/gthumb.xml
+++ b/release/gthumb.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2011 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    Cleaner for gthumb by nodiscc
+    Copyright © 2013 nodiscc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="gthumb" os="linux">
+  <label>Gthumb</label>
+  <description>an advanced image viewer and browser</description>
+  <option id="history">
+    <label>History</label>
+    <description>Delete the history of recently used files</description>
+    <action search="glob" command="delete" path="~/.config/gthumb/history.xbel"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
gThumb is an advanced image viewer and browser for the GNOME Desktop
this cleaner deletes the history of recenlty used files in gThumb
