### PR TITLE
add geary cleaner

### DIFF
--- a/pending/geary.xml
+++ b/pending/geary.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2011 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    Cleaner for geary by nodiscc
+    Copyright © 2014 nodiscc
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="geary" os="linux">
+  <label>Geary</label>
+  <description>lightweight email client</description>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete locally cached emails and attachments</description>
+    <action search="walk.all" command="delete" path="~/.local/share/geary/"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
https://wiki.gnome.org/Apps/Geary
Tested with geary 0.8.2-1 on Debian
Removed 133MB of emails/attachments on my system
