### PR TITLE
update headers and copyright information

### DIFF
--- a/release/adanaxis.xml
+++ b/release/adanaxis.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Adanaxis cleaner

--- a/release/adanaxis.xml
+++ b/release/adanaxis.xml
@@ -6,8 +6,8 @@
     http://bleachbit.sourceforge.net
 
     Adanaxis cleaner
-    Copyright (C) 2010-2014 Andrew Ziem
-    Copyright (C) 2010-2014 juancarlospaco
+    Copyright (C) 2009 Andrew Ziem
+    Copyright (C) 2009 juancarlospaco
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/adanaxis.xml
+++ b/release/adanaxis.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Adanaxis cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/adanaxis.xml
+++ b/release/adanaxis.xml
@@ -7,6 +7,7 @@
 
     Adanaxis cleaner
     Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 juancarlospaco
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/autojump.xml
+++ b/release/autojump.xml
@@ -2,12 +2,12 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Autojump cleaner
-    Copyright (C) 2010-2014 Manuel E. Gutierrez
-    Copyright (C) 2010-2014 nodiscc
+    Copyright (C) 2013 Manuel E. Gutierrez
+    Copyright (C) 2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/autojump.xml
+++ b/release/autojump.xml
@@ -2,11 +2,12 @@
 <!--
 
     BleachBit
-    Copyright (C) 2011 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    Cleaner for Autojump by xr09
-    Copyright © 2013 xr09
+    Autojump cleaner
+    Copyright (C) 2010-2014 Manuel E. Gutierrez
+    Copyright (C) 2010-2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/eshell.xml
+++ b/release/eshell.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Eshell cleaner

--- a/release/eshell.xml
+++ b/release/eshell.xml
@@ -6,7 +6,7 @@
     http://bleachbit.sourceforge.net
 
     Eshell cleaner
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2012 Theatre-X
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/eshell.xml
+++ b/release/eshell.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2011 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Eshell cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/fbcim.xml
+++ b/release/fbcim.xml
@@ -2,10 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2014 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    Cleaner contributed by "Theatre X"
+    Facebook Messenger cleaner
+    Copyright (C) 2010-2014 Theatre-X
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/fbcim.xml
+++ b/release/fbcim.xml
@@ -2,11 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Facebook Messenger cleaner
-    Copyright (C) 2010-2014 Theatre-X
+    Copyright (C) 2012, 2014 Theatre-X
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gnash.xml
+++ b/release/gnash.xml
@@ -6,7 +6,7 @@
     http://bleachbit.sourceforge.net
     
     Gnash cleaner
-    Copyright (C) 2010-2014 Theatre-X
+    Copyright (C) 2011 Theatre-X
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gnash.xml
+++ b/release/gnash.xml
@@ -2,10 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2014 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
     
-    Cleaner by "Theatre-X"
+    Gnash cleaner
+    Copyright (C) 2010-2014 Theatre-X
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gnash.xml
+++ b/release/gnash.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
     
     Gnash cleaner

--- a/release/gnome-art.xml
+++ b/release/gnome-art.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Gnome-art cleaner

--- a/release/gnome-art.xml
+++ b/release/gnome-art.xml
@@ -6,8 +6,7 @@
     http://bleachbit.sourceforge.net
 
     Gnome-art cleaner
-    Copyright (C) 2010-2014 Andrew Ziem
-    Copyright (C) 2010-2014 Roman Horník
+    Copyright (C) 2010-2009 Roman Horník
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gnome-art.xml
+++ b/release/gnome-art.xml
@@ -7,6 +7,7 @@
 
     Gnome-art cleaner
     Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 Roman Horník
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gnome-art.xml
+++ b/release/gnome-art.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Gnome-art cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gthumb.xml
+++ b/release/gthumb.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Gthumb cleaner

--- a/release/gthumb.xml
+++ b/release/gthumb.xml
@@ -6,7 +6,7 @@
     http://bleachbit.sourceforge.net
 
     Gthumb cleaner
-    Copyright (C) 2010-2014 nodiscc
+    Copyright (C) 2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gthumb.xml
+++ b/release/gthumb.xml
@@ -2,11 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2011 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    Cleaner for gthumb by nodiscc
-    Copyright © 2013 nodiscc
+    Gthumb cleaner
+    Copyright (C) 2010-2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/gvfs.xml
+++ b/release/gvfs.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     GVFS cleaner

--- a/release/gvfs.xml
+++ b/release/gvfs.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2013 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    GVFS cleaner
+    Copyright (C) 2010-2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/icedove.xml
+++ b/release/icedove.xml
@@ -2,9 +2,12 @@
 <!--
 
     BleachBit
-    Copyright (C) 2013 Andrew Ziem
-    Converted from thunderbird.xml by Stephen Lyons 2014
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Icedove cleaner
+    Copyright (C) 2010-2014 Stephen Lyons
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/icedove.xml
+++ b/release/icedove.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Icedove cleaner

--- a/release/infrarecorder.xml
+++ b/release/infrarecorder.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 BleachBit
-Copyright (C) 2014 Andrew Ziem
+Copyright (C) 2010-2014 Andrew Ziem
 http://bleachbit.sourceforge.net
+
+InfraRecorder cleaner
+Copyright (C) 2010-2014 Theatre-X
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/release/infrarecorder.xml
+++ b/release/infrarecorder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 BleachBit
-Copyright (C) 2010-2014 Andrew Ziem
+Copyright (C) 2009 Andrew Ziem
 http://bleachbit.sourceforge.net
 
 InfraRecorder cleaner

--- a/release/kodi_xbmc.xml
+++ b/release/kodi_xbmc.xml
@@ -5,10 +5,9 @@
     Copyright (C) 2015 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    This cleaner:
+    XBMC cleaner for Bleachbit
     Copyright (C) 2009 Roman Horník
-    https://launchpad.net/~roman.hornik
-    Copyright © 2013 Rogério Theodoro de Brito.
+    Copyright (C) 2013 Rogério Theodoro de Brito
 
     Modification for Kodi by Theatre X (2015)
 

--- a/release/lives.xml
+++ b/release/lives.xml
@@ -2,12 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    This cleaner:
+    LiVES cleaner
     Copyright (C) 2009 Roman Horník
-    https://launchpad.net/~roman.hornik
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/lives.xml
+++ b/release/lives.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     LiVES cleaner

--- a/release/metacity.xml
+++ b/release/metacity.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Metacity cleaner

--- a/release/metacity.xml
+++ b/release/metacity.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Metacity cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/midori.xml
+++ b/release/midori.xml
@@ -2,12 +2,17 @@
 <!--
 
     BleachBit
-    Copyright (C) 2014 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
     
-    Cleaner for Midori by SpaceCafé and Theatre X
+    Midori cleaner
     from <https://bugs.launchpad.net/bleachbit/+bug/571114>
-    Copyright © 2014 Rogério Theodoro de Brito.
+    Copyright (C) 2010-2014 Rogério Theodoro de Brito
+    Copyright (C) 2010-2014 nodiscc
+    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 Theatre-X
+    Copyright (C) 2010-2014 SpaceCafé
+
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/midori.xml
+++ b/release/midori.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
     
     Midori cleaner

--- a/release/mysql.xml
+++ b/release/mysql.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    MySQL cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/mysql.xml
+++ b/release/mysql.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     MySQL cleaner

--- a/release/notify-osd.xml
+++ b/release/notify-osd.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     notify-osd cleaner

--- a/release/notify-osd.xml
+++ b/release/notify-osd.xml
@@ -7,6 +7,7 @@
 
     notify-osd cleaner
     Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 juancarlospaco
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/notify-osd.xml
+++ b/release/notify-osd.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    notify-osd cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/pdfedit.xml
+++ b/release/pdfedit.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     PDFEdit cleaner

--- a/release/pdfedit.xml
+++ b/release/pdfedit.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    PDFEdit cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/pdfedit.xml
+++ b/release/pdfedit.xml
@@ -7,6 +7,7 @@
 
     PDFEdit cleaner
     Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 juancarlospaco
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/phatch.xml
+++ b/release/phatch.xml
@@ -3,8 +3,11 @@
 
     BleachBit
     Copyright (C) 2009 Andrew Ziem
-    Copyright (C) 2009 juancarlospaco
     http://bleachbit.sourceforge.net
+
+    Phatch cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 juancarlospaco
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/playonlinux.xml
+++ b/release/playonlinux.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 	
   	PlayOnLinux cleaner for BleachBit

--- a/release/playonlinux.xml
+++ b/release/playonlinux.xml
@@ -7,6 +7,7 @@
 	
   	PlayOnLinux cleaner for BleachBit
 	  Copyright (C) 2013 Alexander Schlarb
+    Copyright (C) 2010-2014 juancarlospaco
 	
   	This program is free software: you can redistribute it and/or modify
   	it under the terms of the GNU General Public License as published by

--- a/release/playonlinux.xml
+++ b/release/playonlinux.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+
+    BleachBit
+    Copyright (C) 2010-2014 Andrew Ziem
+    http://bleachbit.sourceforge.net
 	
-	PlayOnLinux cleaner for BleachBit
-	Copyright (C) 2013 Alexander Schlarb
+  	PlayOnLinux cleaner for BleachBit
+	  Copyright (C) 2013 Alexander Schlarb
 	
-	This program is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+  	This program is free software: you can redistribute it and/or modify
+  	it under the terms of the GNU General Public License as published by
+  	the Free Software Foundation, either version 3 of the License, or
+  	(at your option) any later version.
 	
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-	GNU General Public License for more details.
+  	This program is distributed in the hope that it will be useful,
+  	but WITHOUT ANY WARRANTY; without even the implied warranty of
+  	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  	GNU General Public License for more details.
 	
-	You should have received a copy of the GNU General Public License
-	along with this program. If not, see <http://www.gnu.org/licenses/>.
+  	You should have received a copy of the GNU General Public License
+  	along with this program. If not, see <http://www.gnu.org/licenses/>.
 	
 -->
 <cleaner id="playonlinux" os="linux">

--- a/release/shotwell.xml
+++ b/release/shotwell.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Shotwell cleaner

--- a/release/shotwell.xml
+++ b/release/shotwell.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2013 nodiscc
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Shotwell cleaner
+    Copyright (C) 2010-2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/syslogs.xml
+++ b/release/syslogs.xml
@@ -2,12 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    This cleaner
-    Copyright © 2009 Roman Horník
-    https://launchpad.net/~roman.hornik
+    System logs cleaner
+    Copyright (C) 2009-2014 Roman Horník
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/syslogs.xml
+++ b/release/syslogs.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     System logs cleaner

--- a/release/ubuntuone.xml
+++ b/release/ubuntuone.xml
@@ -2,7 +2,7 @@
 <!--
 
 BleachBit
-Copyright (C) 2010-2014 Andrew Ziem
+Copyright (C) 2009 Andrew Ziem
 http://bleachbit.sourceforge.net
 
 UbutuOne cleaner

--- a/release/ubuntuone.xml
+++ b/release/ubuntuone.xml
@@ -2,10 +2,11 @@
 <!--
 
 BleachBit
-Copyright (C) 2014 Andrew Ziem
+Copyright (C) 2010-2014 Andrew Ziem
 http://bleachbit.sourceforge.net
 
-Cleaner by Theatre-X
+UbutuOne cleaner
+Copyright (C) 2010-2014 Theatre-X
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/release/ubuntuswc.xml
+++ b/release/ubuntuswc.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Ubuntu Software Center cleaner

--- a/release/ubuntuswc.xml
+++ b/release/ubuntuswc.xml
@@ -2,10 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2014 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
-    Cleaner by "Theatre-X"
+    Ubuntu Software Center cleaner
+    Copyright (C) 2010-2014 Theatre-X
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/virt-manager.xml
+++ b/release/virt-manager.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Virt-manager cleaner

--- a/release/virt-manager.xml
+++ b/release/virt-manager.xml
@@ -7,6 +7,7 @@
 
     Virt-manager cleaner
     Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 juancarlospaco
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/virt-manager.xml
+++ b/release/virt-manager.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Virt-manager cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/wesnoth.xml
+++ b/release/wesnoth.xml
@@ -2,10 +2,14 @@
 <!--
 
     BleachBit
+
     Copyright (C) 2009, 2010 Andrew Ziem
-    Copyright (C) 2010 Thibault Févry
-    Copyright (C) 2014 tiemay
     http://bleachbit.sourceforge.net
+
+    Wesnoth cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2014 tiemay
+    Copyright (C) 2010 Thibault Févry
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/wesnoth.xml
+++ b/release/wesnoth.xml
@@ -3,7 +3,7 @@
 
     BleachBit
 
-    Copyright (C) 2009, 2010 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Wesnoth cleaner

--- a/release/xfce.xml
+++ b/release/xfce.xml
@@ -2,9 +2,12 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
 
+    XFCE cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
+    
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/release/xfce.xml
+++ b/release/xfce.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     XFCE cleaner

--- a/release/xmoto.xml
+++ b/release/xmoto.xml
@@ -7,6 +7,7 @@
 
     Xmoto cleaner
     Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2010-2014 SpaceCafé
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/xmoto.xml
+++ b/release/xmoto.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Xmoto cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/xmoto.xml
+++ b/release/xmoto.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Xmoto cleaner

--- a/release/zeitgeist.xml
+++ b/release/zeitgeist.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     Zeitgeist cleaner for BleachBit

--- a/release/zeitgeist.xml
+++ b/release/zeitgeist.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2013 nodiscc
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    Zeitgeist cleaner for BleachBit
+    Copyright (C) 2014 nodiscc
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/zsh.xml
+++ b/release/zsh.xml
@@ -2,8 +2,11 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010 Andrew Ziem
+    Copyright (C) 2010-2014 Andrew Ziem
     http://bleachbit.sourceforge.net
+
+    ZSH cleaner
+    Copyright (C) 2010-2014 Andrew Ziem
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/release/zsh.xml
+++ b/release/zsh.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2010-2014 Andrew Ziem
+    Copyright (C) 2009 Andrew Ziem
     http://bleachbit.sourceforge.net
 
     ZSH cleaner


### PR DESCRIPTION
Authoring info obtained using `git shortlog -sne` and `git blame`
Headers are now uniformized (except indentation)