### PR TITLE
Add Voxelands

### DIFF
--- a/pending/voxelands.xml
+++ b/pending/voxelands.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2014 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="voxelands" os="linux">
+  <label>Voxelands</label>
+  <description>3D voxel world game</description>
+  <option id="debug_logs">
+    <label>Debug logs</label>
+    <description>Delete the debug logs</description>
+    <action command="delete" search="file" path="~/.voxelands/debug.txt"/>
+  </option>
+  <option id="worlds">
+    <label>Compress world</label>
+    <description>Compress the world database to make it occupy less disk space without deleting it.</description>
+    <warning>This option is slow.</warning>
+    <action command="sqlite.vacuum" search="file" path="~/.voxelands/world/map.sqlite"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Cleaner for Voxelands (http://www.voxelands.com/).

* Deleting the debug file is a real killer as it grows and grows and growns … The last time I did it is was above 800 MB!
* The world can be compressed since it is stored as SQLite3. The last time it saved me a lousy 1.7 MB. :D

All tested on GNU/Linux 4.1.2 (Arch Linux), Voxelands 1508.01.

The cleaner is only made for GNU/Linux, but Voxelands is also available for Windows and Mac OS, but I don't know the directories, so it is GNU/Linux-only for now. :-(

NOTE: In this document, I used the following conversions: 1 kB = 1000 B, 1 MB = 1000 kB. Sorry for the confusion, but this is because BleachBit uses factor 1000 (and I am too lazy to recalculate :P)