### PR TITLE
Add Xonotic

### DIFF
--- a/pending/xonotic.xml
+++ b/pending/xonotic.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2008-2015 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="xonotic" os="linux">
+  <label>Xonotic</label>
+  <description>First-person shooter game</description>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the cache</description>
+    <action command="delete" search="walk.files" path="~/.xonotic/data/dlcache/"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Cleaner for Xonotic (http://www.xonotic.org/).
Basically it is the same for Nexuiz (aka “Nexuix Classic” by AlienTrap, http://www.alientrap.org/games/nexuiz), I used the original nexuiz.xml file and only needed to change the folder.

Only 1 option, cleaning the download cache. It saved me over 100 MB the last time. The download cache gets larger if you play a lot online.

All tested on GNU/Linux 4.1.2 (Arch Linux), Xonotic 0.8.0.

The cleaner is only made for GNU/Linux, but Xonotic is also available for other OSes, but I don't know the directories, so it is GNU/Linux-only for now. :-(

NOTE: In this document, I used the following conversions: 1 kB = 1000 B, 1 MB = 1000 kB. Sorry for the confusion, but this is because BleachBit uses factor 1000 (and I am too lazy to recalculate :P)