### PR TITLE
Add world compression to Minetest Classic

### DIFF
--- a/pending/minetest_classic.xml
+++ b/pending/minetest_classic.xml
@@ -27,4 +27,10 @@
     <description>Delete the debug logs</description>
     <action command="delete" search="file" path="~/.minetest-classic/debug.txt"/>
   </option>
+  <option id="worlds">
+    <label>Compress world</label>
+    <description>Compress the world database to make it occupy less disk space without deleting it.</description>
+    <warning>This option is slow.</warning>
+    <action command="sqlite.vacuum" search="file" path="~/.minetest-classic/world/map.sqlite"/>
+  </option>
 </cleaner>


### PR DESCRIPTION
Minetest Classic stores its world in a SQLite database, so let's vacuum it! :)

WARNING: Not directly tested, but tested with Voxelands (see here: https://github.com/az0/cleanerml/pull/97). Voxelands was called “Minetest Classic” earlier.