### PR TITLE
Add Freeminer

### DIFF
--- a/pending/freeminer.xml
+++ b/pending/freeminer.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2015 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="freeminer" os="linux">
+  <label>Freeminer</label>
+  <description>3D voxel world game</description>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the cache</description>
+    <action command="delete" search="walk.all" path="~/.freeminer/cache/"/>
+  </option>
+  <option id="debug_logs">
+    <label>Debug logs</label>
+    <description>Delete the debug logs</description>
+    <action command="delete" search="file" path="~/.freeminer/debug.txt"/>
+  </option>
+  <option id="favorite_server_list">
+    <label>Favorite server list</label>
+    <description>Delete the list of favorite servers</description>
+    <action command="delete" search="file" path="~/.freeminer/client/favoriteservers.json"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Cleaner for Freeminer (http://freeminer.org/), fork of Minetest.

Cleaning options:

* Delete debug files
* Delete list of favorite servers
* Delete cache

File sizes:

* debug.txt can grow surprisingly large if you used Freeminer for a long time. A file sizes of over 900 MiB after a longer period of usage is not uncommon
* The favourite server list is usually rather small, just a few B or KiB
* The cache grows about to sizes of tens of MiB (I can't recall it exactly).

Tested with GNU/Linux (Linux 4.1.2) and Freeminer 0.4.13.7.