### PR TITLE
Add Hedgewars

### DIFF
--- a/pending/hedgewars.xml
+++ b/pending/hedgewars.xml
@@ -1,0 +1,35 @@
+<!--
+
+    BleachBit
+    Copyright (C) 2015 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<cleaner id="hedgewars" os="linux">
+  <label>Hedgewars</label>
+  <description>Turn-based artillery strategy game</description>
+  <option id="debug_logs">
+    <label>Debug logs</label>
+    <description>Delete the debug logs</description>
+    <action command="delete" search="glob" path="~/.hedgewars/Logs/*.log"/>
+  </option>
+  <option id="temp_videos">
+    <label>Video snippets</label>
+    <description>Delete temporary video snippets and data of recorded videos (not demos!).</description>
+    <action command="delete" search="walk.files" path="~/.hedgewars/VideoTemp/"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Cleaner for Hedgewars (http://www.hedgewars.org/).

Features:

* Delete logs
* Delete temporary video files (not demos!)

All tested on GNU/Linux, Linux 4.1.2 (Arch Linux), Hedgewars 0.9.22.

* Deleting logs doesn't save much space. Usually not more than 100 kB, but if you record videos it may become signiciantly larger, especially for long videos.
* After a 2 minute test session Hedgewars generated 25.1 MB of data. After you recorded videos there are some temporary leftover files which are not the “real” videos. Hedgewars does not appear to delete them (or at least not completely)

The cleaner is only made for GNU/Linux, but Hedgewars is also available for other OSes, but I don't know the directories, so it is GNU/Linux-only for now. :-(

NOTE: In this document, I used the following conversions: 1 kB = 1000 B, 1 MB = 1000 kB. Sorry for the confusion, but this is because BleachBit uses factor 1000 (and I am too lazy to recalculate :P)