### PR TITLE
Add JOSM

### DIFF
--- a/pending/josm.xml
+++ b/pending/josm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2015 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="josm" os="linux">
+  <label>JOSM</label>
+  <description>Editor for OpenStreetMap</description>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the cache</description>
+    <action command="delete" search="walk.all" path="~/.josm/cache"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
I added a JOSM cleaner. JOSM is a program for editing the OpenStreetMap.

There is only one cleaner, cleaning the cache.

I am a heavy OpenStreetMap mapper since many years and thus the cache has thus accumulated a lot of junk. With this file I cleaned it the first time. Cleaning the cache has freed **1.76 GiB** for me!

Tested on GNU/Linux, JOSM version 8800.

Sadly, this cleaner is GNU/Linux only, although JOSM is cross-platform. I just don't know the relevant directories for the other OSes.