### PR TITLE
Fix Hedgewars' XML header

### DIFF
--- a/pending/hedgewars.xml
+++ b/pending/hedgewars.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     BleachBit
@@ -18,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <cleaner id="hedgewars" os="linux">
   <label>Hedgewars</label>
   <description>Turn-based artillery strategy game</description>


### PR DESCRIPTION
Oops, the Hedgewars file I posted earlier was incorrect.
The XML header was not at the start of the file.

To be sure, I made a quick re-test with BleachBit.