### PR TITLE
Added support for OpenRA

### DIFF
--- a/pending/openra.xml
+++ b/pending/openra.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2016 Andrew Ziem
+    http://bleachbit.sourceforge.net
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="openra" os="linux">
+  <label>OpenRA</label>
+  <description>Reimaging of early Westwood RTS games</description>
+  <option id="content">
+    <label>Game Assets</label>
+    <description>Delete the game assets</description>
+    <action command="delete" search="walk.files" path="~/.openra/Content"/>
+  </option>
+  <option id="replays">
+    <label>Replays</label>
+    <description>Delete recorded game replays</description>
+    <action command="delete" search="walk.files" path="~/.openra/Replays"/>
+  </option>
+  <option id="maps">
+    <label>Maps</label>
+    <description>Delete downloaded custom maps</description>
+    <action command="delete" search="walk.files" path="~/.openra/Maps"/>
+  </option>
+  <option id="logs">
+    <label>Logs</label>
+    <description>Delete debug logs</description>
+    <action command="delete" search="walk.files" path="~/.openra/Logs"/>
+  </option>
+  <option id="settings">
+    <label>Settings</label>
+    <description>Delete saved settings</description>
+    <action command="delete" search="file" path="~/.openra/settings.yaml"/>
+  </option>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete temporary files</description>
+    <action command="delete" search="file" path="~/.openra/news.yaml"/>
+    <action command="delete" search="file" path="~/.openra/motd.txt"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
@OpenRA is a game engine which leaves some traces during uninstall such as the original game assets and for regular players the replay folder can also amass a lot of files.