### PR TITLE
Windows memory dumps

### DIFF
--- a/pending/memorydumps.xml
+++ b/pending/memorydumps.xml
@@ -23,8 +23,8 @@
   <option id="dumps">
     <label>Memory Dumps</label>
     <description>Deletes Windows memory dump files</description>
-    <action command="delete" search="file" path="$WINDIR/memory.dmp/>
-    <action command="delete" search="glob" path="$WINDIR/MiniDump/*.dmp>
-    <action command="delete" search="glob" path="$APPDATA/Local/CrashDumps/*.dmp>
+    <action command="delete" search="file" path="$WINDIR/memory.dmp"/>
+    <action command="delete" search="glob" path="$WINDIR/MiniDump/*.dmp"/>
+    <action command="delete" search="glob" path="$APPDATA/Local/CrashDumps/*.dmp"/>
   </option>
 </cleaner>

--- a/pending/memorydumps.xml
+++ b/pending/memorydumps.xml
@@ -23,8 +23,8 @@
   <option id="dumps">
     <label>Memory Dumps</label>
     <description>Deletes Windows memory dump files</description>
-    <action command="delete" search="file" path="$WINDIR/memory.dmp/
+    <action command="delete" search="file" path="$WINDIR/memory.dmp/>
     <action command="delete" search="glob" path="$WINDIR/MiniDump/*.dmp>
-    <action command="delete" search="glob" path="$APPDATA/Local/CrashDumps/*.dmp
+    <action command="delete" search="glob" path="$APPDATA/Local/CrashDumps/*.dmp>
   </option>
 </cleaner>

--- a/pending/memorydumps.xml
+++ b/pending/memorydumps.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    BleachBit
+    Copyright (C) 2008-2016 Andrew Ziem
+    http://www.bleachbit.org
+
+    Cleaner for Windows memory Dumps by ROCKNROLLKID
+    
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<cleaner id="memorydumps" os="windows">
+  <label>Windows Memory Dumps</label>
+  <description>Memory Dumps</description>
+  <option id="dumps">
+    <label>Memory Dumps</label>
+    <description>Deletes Windows memory dump files</description>
+    <action command="delete" search="file" path="$WINDIR/memory.dmp/
+    <action command="delete" search="glob" path="$WINDIR/MiniDump/*.dmp>
+    <action command="delete" search="glob" path="$APPDATA/Local/CrashDumps/*.dmp
+  </option>
+</cleaner>

--- a/pending/memorydumps.xml
+++ b/pending/memorydumps.xml
@@ -19,7 +19,6 @@
 -->
 <cleaner id="memorydumps" os="windows">
   <label>Windows Memory Dumps</label>
-  <description>Memory Dumps</description>
   <option id="dumps">
     <label>Memory Dumps</label>
     <description>Deletes Windows memory dump files</description>


### PR DESCRIPTION
This is https://github.com/az0/bleachbit/pull/86, except with the Winapp2 entries included. The other PR can be closed. The memory dump entry can be taken out of Winapp2, once this gets merged into CleanerML, as all the other cleaners have it in their own cleaning rules, outside of Winapp2.

This is my first ever trying to understand CleanerML, so there probably is a lot of mistakes.