### PR TITLE
Add cleaner for Vivaldi

### DIFF
--- a/pending/vivaldi.xml
+++ b/pending/vivaldi.xml
@@ -21,6 +21,10 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+    @url https://vivaldi.com/
+    @tested ok 1.11.917.39 (Stable channel) (64-bit), Arch Linux
+    @note I took the google_chrome.xml from the Bleachbit repo and modified it.
+
 -->
 <cleaner id="vivaldi">
   <label>Vivaldi</label>

--- a/pending/vivaldi.xml
+++ b/pending/vivaldi.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2008-2017 Andrew Ziem
+    http://www.bleachbit.org
+
+    Cleaner for Vivaldi
+    Copyright © 2017 r3b311i0n
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="vivaldi">
+  <label>Vivaldi</label>
+  <description>Web browser</description>
+  <running type="exe">vivaldi.exe</running>
+  <running type="exe">vivaldi-bin</running>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the web cache, which reduces time to display revisited pages</description>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\B*.tmp"/>
+    <action command="delete" search="walk.all" path="$localappdata\Vivaldi\User Data\Default\Application Cache\"/>
+    <action command="delete" search="walk.all" path="$localappdata\Vivaldi\User Data\Default\Pepper Data\Shockwave Flash\CacheWritableAdobeRoot\"/>
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\Cache\"/>
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\GPUCache\"/>
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\Media Cache\"/>
+    <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Default\Preferences" address="dns_prefetching/host_referral_list"/>
+    <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Default\Preferences" address="dns_prefetching/startup_list"/>
+    <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Default\Preferences" address="net/http_server_properties/servers"/>
+    <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Local State" address="HostReferralList"/>
+    <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Local State" address="StartupDNSPrefetchList"/>
+    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/Default/Pepper Data/Shockwave Flash/CacheWritableAdobeRoot/"/>
+    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/Default/Application Cache/"/>
+    <action command="delete" search="walk.files" path="$XDG_CACHE_HOME/vivaldi/"/>
+    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Preferences" address="dns_prefetching/host_referral_list"/>
+    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Preferences" address="dns_prefetching/startup_list"/>
+    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Preferences" address="net/http_server_properties/servers"/>
+    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Local State" address="HostReferralList"/>
+    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Local State" address="StartupDNSPrefetchList"/>
+  </option>
+  <option id="cookies">
+    <label>Cookies</label>
+    <description>Delete cookies, which contain information such as web site preferences, authentication, and tracking identification</description>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\*\Cookies"/>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\*\Cookies-journal"/>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\*\Extension Cookies"/>
+    <action command="delete" search="walk.all" path="$localappdata\Vivaldi\User Data\*\Pepper Data\Shockwave Flash\WritableRoot\"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/*/Cookies"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/*/Cookies-journal"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/*/Extension Cookies"/>
+    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/*/Pepper Data/Shockwave Flash/WritableRoot/"/>
+  </option>
+  <option id="dom">
+    <label>DOM Storage</label>
+    <description>Delete HTML5 cookies</description>
+    <!-- Examples for Google Chrome 7.0 on Fedora 13.  Notice we avoid deleting extension (add-on) preferences.
+        ~/.config/google-chrome/Default/Local Storage/chrome-extension_mmffncokckfccddfenhkhnllmlobdahm_0.localstorage
+        ~/.config/google-chrome/Default/Local Storage/http_samy.pl_0.localstorage -->
+    <action command="chrome.databases_db" search="file" path="$localappdata\Vivaldi\User Data\Default\databases\Databases.db"/>
+    <action command="chrome.databases_db" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/Databases.db"/>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\Default\Local Storage\http*localstorage"/>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\Default\Local Storage\http*localstorage-journal"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/Local Storage/http*localstorage"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/Local Storage/http*localstorage-journal"/>
+    <action command="delete" search="walk.all" path="$localappdata\Vivaldi\User Data\Default\databases\http*\"/>
+    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/http*/"/>
+  </option>
+  <option id="form_history">
+    <label>Form history</label>
+    <description>A history of forms entered in web sites</description>
+    <action command="chrome.autofill" search="file" path="$localappdata\Vivaldi\User Data\Default\Web Data"/>
+    <action command="chrome.autofill" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Web Data"/>
+  </option>
+  <option id="history">
+    <label>History</label>
+    <description>Delete the history which includes visited sites, downloads, and thumbnails</description>
+    <!-- keep /History before /Favicons -->
+    <action command="chrome.history" search="file" path="$localappdata\Vivaldi\User Data\Default\History"/>
+    <action command="chrome.favicons" search="file" path="$localappdata\Vivaldi\User Data\Default\Favicons"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\chrome_shutdown_ms.txt"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Safe Browsing Cookies-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Archived History"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Archived History-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\History Provider Cache"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\History-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Network Action Predictor"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Network Action Predictor-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Origin Bound Certs-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\QuotaManager-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Shortcuts"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Shortcuts-journal"/>
+    <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\Thumbnails"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Thumbnails"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Thumbnails-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Top Sites"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Top Sites-journal"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Visited Links"/>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\Default\History Index ????-??"/>
+    <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\Default\History Index ????-??-journal"/>
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\Session Storage\"/>
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\JumpListIcons\"/>
+    <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\JumpListIconsOld\"/>
+    <action command="chrome.history" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History"/>
+    <action command="chrome.favicons" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Favicons"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/chrome_shutdown_ms.txt"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Safe Browsing Cookies-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Archived History"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Archived History-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History Provider Cache"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Network Action Predictor"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Network Action Predictor-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Origin Bound Certs-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Shortcuts"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Shortcuts-journal"/>
+    <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails"/>
+    <action command="delete" search="walk.files" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Top Sites"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Top Sites-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Visited Links"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/History Index ????-??"/>
+    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/History Index ????-??-journal"/>
+    <action command="delete" search="walk.files" path="$XDG_CONFIG_HOME/vivaldi/Default/Session Storage/"/>
+    <action command="delete" search="walk.files" path="$XDG_CONFIG_HOME/vivaldi/Default/Sync Data Backup/"/>
+  </option>
+  <option id="passwords">
+    <label>Passwords</label>
+    <description>A database of usernames and passwords as well as a list of sites that should not store passwords</description>
+    <warning>This option will delete your saved passwords.</warning>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Login Data"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Login Data-journal"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Login Data"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Login Data-journal"/>
+  </option>
+  <option id="search_engines">
+    <label>Search engines</label>
+    <description translators="'Factory' means a search engine that is installed by default 'from the factory,' but this is different than a 'default search engine' https://lists.launchpad.net/launchpad-translators/msg00283.html">Reset the search engine usage history and delete non-factory search engines, some of which are added automatically</description>
+    <action command="chrome.keywords" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Web Data"/>
+    <action command="chrome.keywords" search="file" path="$localappdata\Vivaldi\User Data\Default\Web Data"/>
+  </option>
+  <option id="session">
+    <label>Session</label>
+    <description>Delete the current and last sessions</description>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Current Session"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Current Tabs"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Last Session"/>
+    <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Last Tabs"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Current Session"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Current Tabs"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Last Session"/>
+    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Last Tabs"/>
+  </option>
+  <option id="vacuum">
+    <label>Vacuum</label>
+    <description>Clean database fragmentation to reduce space and improve speed without removing any data</description>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Archived History"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Extension Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\History"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Plugin Data\Google Gears\localserver.db"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Plugin Data\Google Gears\permissions.db"/>
+    <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Thumbnails" type="f"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Top Sites"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\Web Data"/>
+    <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\databases\Databases.db"/>
+    <action command="sqlite.vacuum" search="glob" path="$localappdata\Vivaldi\User Data\Default\History Index ????-??"/>
+    <action command="sqlite.vacuum" search="glob" path="$localappdata\Vivaldi\User Data\Default\databases\http*\?"/>
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Extension Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History"/>
+    <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails" type="f"/>
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Top Sites"/>
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Web Data"/>
+    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/Databases.db"/>
+    <action command="sqlite.vacuum" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/History Index ????-??"/>
+    <action command="sqlite.vacuum" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/http*/?"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
Cleaner for [Vivaldi](https://vivaldi.com) Web Browser

* Tested Platform: Arch Linux
* Tested Version: 1.11.917.39 (Stable channel) (64-bit)

I took the [google_chrome.xml](https://github.com/bleachbit/bleachbit/blob/master/cleaners/google_chrome.xml) from the [Bleachbit](https://github.com/bleachbit/bleachbit) repo and modified it.