### PR TITLE
[vivaldi] fix vivaldi on linux, adding localstorage and indexdb cleaners

### DIFF
--- a/pending/vivaldi.xml
+++ b/pending/vivaldi.xml
@@ -45,14 +45,14 @@
     <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Default\Preferences" address="net/http_server_properties/servers"/>
     <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Local State" address="HostReferralList"/>
     <action command="json" search="file" path="$localappdata\Vivaldi\User Data\Local State" address="StartupDNSPrefetchList"/>
-    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/Default/Pepper Data/Shockwave Flash/CacheWritableAdobeRoot/"/>
-    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/Default/Application Cache/"/>
-    <action command="delete" search="walk.files" path="$XDG_CACHE_HOME/vivaldi/"/>
-    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Preferences" address="dns_prefetching/host_referral_list"/>
-    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Preferences" address="dns_prefetching/startup_list"/>
-    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Preferences" address="net/http_server_properties/servers"/>
-    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Local State" address="HostReferralList"/>
-    <action command="json" search="file" path="$XDG_CONFIG_HOME/vivaldi/Local State" address="StartupDNSPrefetchList"/>
+    <action command="delete" search="walk.all" path="~/.config/vivaldi/Default/Pepper Data/Shockwave Flash/CacheWritableAdobeRoot/"/>
+    <action command="delete" search="walk.all" path="~/.config/vivaldi/Default/Application Cache/"/>
+    <action command="delete" search="walk.files" path="~/.cache/vivaldi/"/>
+    <action command="json" search="file" path="~/.config/vivaldi/Default/Preferences" address="dns_prefetching/host_referral_list"/>
+    <action command="json" search="file" path="~/.config/vivaldi/Default/Preferences" address="dns_prefetching/startup_list"/>
+    <action command="json" search="file" path="~/.config/vivaldi/Default/Preferences" address="net/http_server_properties/servers"/>
+    <action command="json" search="file" path="~/.config/vivaldi/Local State" address="HostReferralList"/>
+    <action command="json" search="file" path="~/.config/vivaldi/Local State" address="StartupDNSPrefetchList"/>
   </option>
   <option id="cookies">
     <label>Cookies</label>
@@ -61,10 +61,10 @@
     <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\*\Cookies-journal"/>
     <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\*\Extension Cookies"/>
     <action command="delete" search="walk.all" path="$localappdata\Vivaldi\User Data\*\Pepper Data\Shockwave Flash\WritableRoot\"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/*/Cookies"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/*/Cookies-journal"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/*/Extension Cookies"/>
-    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/*/Pepper Data/Shockwave Flash/WritableRoot/"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/*/Cookies"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/*/Cookies-journal"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/*/Extension Cookies"/>
+    <action command="delete" search="walk.all" path="~/.config/vivaldi/*/Pepper Data/Shockwave Flash/WritableRoot/"/>
   </option>
   <option id="dom">
     <label>DOM Storage</label>
@@ -73,19 +73,19 @@
         ~/.config/google-chrome/Default/Local Storage/chrome-extension_mmffncokckfccddfenhkhnllmlobdahm_0.localstorage
         ~/.config/google-chrome/Default/Local Storage/http_samy.pl_0.localstorage -->
     <action command="chrome.databases_db" search="file" path="$localappdata\Vivaldi\User Data\Default\databases\Databases.db"/>
-    <action command="chrome.databases_db" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/Databases.db"/>
+    <action command="chrome.databases_db" search="file" path="~/.config/vivaldi/Default/databases/Databases.db"/>
     <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\Default\Local Storage\http*localstorage"/>
     <action command="delete" search="glob" path="$localappdata\Vivaldi\User Data\Default\Local Storage\http*localstorage-journal"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/Local Storage/http*localstorage"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/Local Storage/http*localstorage-journal"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/Default/Local Storage/http*localstorage"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/Default/Local Storage/http*localstorage-journal"/>
     <action command="delete" search="walk.all" path="$localappdata\Vivaldi\User Data\Default\databases\http*\"/>
-    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/http*/"/>
+    <action command="delete" search="walk.all" path="~/.config/vivaldi/Default/databases/http*/"/>
   </option>
   <option id="form_history">
     <label>Form history</label>
     <description>A history of forms entered in web sites</description>
     <action command="chrome.autofill" search="file" path="$localappdata\Vivaldi\User Data\Default\Web Data"/>
-    <action command="chrome.autofill" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Web Data"/>
+    <action command="chrome.autofill" search="file" path="~/.config/vivaldi/Default/Web Data"/>
   </option>
   <option id="history">
     <label>History</label>
@@ -117,30 +117,30 @@
     <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\Session Storage\"/>
     <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\JumpListIcons\"/>
     <action command="delete" search="walk.files" path="$localappdata\Vivaldi\User Data\Default\JumpListIconsOld\"/>
-    <action command="chrome.history" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History"/>
-    <action command="chrome.favicons" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Favicons"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/chrome_shutdown_ms.txt"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Safe Browsing Cookies-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Archived History"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Archived History-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History Provider Cache"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Network Action Predictor"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Network Action Predictor-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Origin Bound Certs-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Shortcuts"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Shortcuts-journal"/>
+    <action command="chrome.history" search="file" path="~/.config/vivaldi/Default/History"/>
+    <action command="chrome.favicons" search="file" path="~/.config/vivaldi/Default/Favicons"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/chrome_shutdown_ms.txt"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Safe Browsing Cookies-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Archived History"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Archived History-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/History Provider Cache"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/History-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Network Action Predictor"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Network Action Predictor-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Origin Bound Certs-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Shortcuts"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Shortcuts-journal"/>
     <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails"/>
-    <action command="delete" search="walk.files" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Top Sites"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Top Sites-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Visited Links"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/History Index ????-??"/>
-    <action command="delete" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/History Index ????-??-journal"/>
-    <action command="delete" search="walk.files" path="$XDG_CONFIG_HOME/vivaldi/Default/Session Storage/"/>
-    <action command="delete" search="walk.files" path="$XDG_CONFIG_HOME/vivaldi/Default/Sync Data Backup/"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Thumbnails"/>
+    <action command="delete" search="walk.files" path="~/.config/vivaldi/Default/Thumbnails"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Thumbnails-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Top Sites"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Top Sites-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Visited Links"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/Default/History Index ????-??"/>
+    <action command="delete" search="glob" path="~/.config/vivaldi/Default/History Index ????-??-journal"/>
+    <action command="delete" search="walk.files" path="~/.config/vivaldi/Default/Session Storage/"/>
+    <action command="delete" search="walk.files" path="~/.config/vivaldi/Default/Sync Data Backup/"/>
   </option>
   <option id="passwords">
     <label>Passwords</label>
@@ -148,13 +148,13 @@
     <warning>This option will delete your saved passwords.</warning>
     <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Login Data"/>
     <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Login Data-journal"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Login Data"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Login Data-journal"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Login Data"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Login Data-journal"/>
   </option>
   <option id="search_engines">
     <label>Search engines</label>
     <description translators="'Factory' means a search engine that is installed by default 'from the factory,' but this is different than a 'default search engine' https://lists.launchpad.net/launchpad-translators/msg00283.html">Reset the search engine usage history and delete non-factory search engines, some of which are added automatically</description>
-    <action command="chrome.keywords" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Web Data"/>
+    <action command="chrome.keywords" search="file" path="~/.config/vivaldi/Default/Web Data"/>
     <action command="chrome.keywords" search="file" path="$localappdata\Vivaldi\User Data\Default\Web Data"/>
   </option>
   <option id="session">
@@ -164,10 +164,21 @@
     <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Current Tabs"/>
     <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Last Session"/>
     <action command="delete" search="file" path="$localappdata\Vivaldi\User Data\Default\Last Tabs"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Current Session"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Current Tabs"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Last Session"/>
-    <action command="delete" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Last Tabs"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Current Session"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Current Tabs"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Last Session"/>
+    <action command="delete" search="file" path="~/.config/vivaldi/Default/Last Tabs"/>
+  </option>
+  <option id="Indexed DB">
+    <label>Local Storage IndexedDB</label>
+    <description>Delete the Local Storage</description>
+    <action command="delete" search="walk.all" path="~/.config/vivaldi/Default/IndexedDB/http*"/>
+  </option>
+  <option id="Local Storage">
+    <label>Local Storage GlobalDB</label>
+    <description>Delete the Local Storage</description>
+    <warning>This option may delete some extension data.</warning>
+    <action command="delete" search="walk.all" path="~/.config/vivaldi/Default/Local Storage/leveldb"/>
   </option>
   <option id="vacuum">
     <label>Vacuum</label>
@@ -185,15 +196,15 @@
     <action command="sqlite.vacuum" search="file" path="$localappdata\Vivaldi\User Data\Default\databases\Databases.db"/>
     <action command="sqlite.vacuum" search="glob" path="$localappdata\Vivaldi\User Data\Default\History Index ????-??"/>
     <action command="sqlite.vacuum" search="glob" path="$localappdata\Vivaldi\User Data\Default\databases\http*\?"/>
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Cookies"/>
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Extension Cookies"/>
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/History"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/Extension Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/History"/>
     <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Thumbnails" type="f"/>
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Top Sites"/>
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/Web Data"/>
-    <action command="sqlite.vacuum" search="file" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/Databases.db"/>
-    <action command="sqlite.vacuum" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/History Index ????-??"/>
-    <action command="sqlite.vacuum" search="glob" path="$XDG_CONFIG_HOME/vivaldi/Default/databases/http*/?"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/Thumbnails" type="f"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/Top Sites"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/Web Data"/>
+    <action command="sqlite.vacuum" search="file" path="~/.config/vivaldi/Default/databases/Databases.db"/>
+    <action command="sqlite.vacuum" search="glob" path="~/.config/vivaldi/Default/History Index ????-??"/>
+    <action command="sqlite.vacuum" search="glob" path="~/.config/vivaldi/Default/databases/http*/?"/>
   </option>
 </cleaner>


### PR DESCRIPTION
the $XDG_ variables don't seem to work for me, and since every other cleaner in this repo uses the regular paths instead I replaced those
added 2 cleaners, cleaning IndexDB folders starting with http,
and another cleaning Local Storage folder (which has multiple LDB files)
also added a warning as clearing Local Storage databases may also break extensions
may be updated if there's a way to clean LevelDB entries separately? then it would be advisable to make the IndexDB and LocalStorage cleaners 1 cleaner

Same cleaners could be added to Chrome as well, as those are also missing there.
#141 
